### PR TITLE
Add dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!metacontroller


### PR DESCRIPTION
Ignore everything except the built artifact.

No big deal but sending large `vendor/` and `.git/` directories is quite unnecessary.

Before/after
```
Sending build context to Docker daemon  117.1MB
---
Sending build context to Docker daemon  29.24MB
```